### PR TITLE
change jshint comment type

### DIFF
--- a/src/service/auth-api-service.js
+++ b/src/service/auth-api-service.js
@@ -54,7 +54,7 @@
             password: '',
 
             /**
-             * Account to log-in into. Required to log-in as an end-user. Defaults to picking it up from the path.
+             * Account to log in into. Required to log in as an end user. Defaults to picking it up from the path.
              * @type {String}
              */
             account: ''
@@ -110,7 +110,7 @@
                     serviceOptions.password = httpOptions.password;
                     serviceOptions.userName = httpOptions.userName;
 
-                    /*jshint camelcase: false */
+                    //jshint camelcase: false 
                     token = response.access_token;
                     store.set(EPI_COOKIE_KEY, token);
 


### PR DESCRIPTION
the generated markdox was including all of the code from “jshint” to
the end of the login function, we don’t want that. (see also
https://github.com/forio/epicenter/commit/0ea9a18ef57f074065bc911880ab43
62664d8c21)

also, remove extra hyphens in updated account description.
