### PR TITLE
Added xhrFields.withCredential = true to allow cookies to be sent

### DIFF
--- a/src/transport/ajax-http-transport.js
+++ b/src/transport/ajax-http-transport.js
@@ -23,7 +23,13 @@
              * ONLY for strings in the url. All GET & DELETE params are run through this
              * @type {[type]}
              */
-            parameterParser: qutils.toQueryFormat
+            parameterParser: qutils.toQueryFormat,
+
+            // To allow epicenter.token and other session cookies to be passed
+            // with the requests
+            xhrFields: {
+                withCredentials: true
+            }
         };
 
         var transportOptions = $.extend({}, defaults, config);


### PR DESCRIPTION
We need this option to allow the epicenter.token cookie to be used automatically in flow.js so it works with private/authenticated projects
