### PR TITLE
fix links, capitalization, etc due to epicenter sprint 2 docs reorg

### DIFF
--- a/documentation/index.html.md
+++ b/documentation/index.html.md
@@ -1,10 +1,10 @@
 ---
-title: "API Adapters"
+title: "Epicenter.js: API Adapters"
 layout: "default"
 isPage: true
 ---
 
-##API Adapters: epicenter.js
+##Epicenter.js: API Adapters
 
 The Epicenter API Adapters are part of the epicenter.js library. This library abstracts the underlying Epicenter RESTful APIs into a set of services and utilities.
 
@@ -12,30 +12,30 @@ If you are comfortable with JavaScript, the epicenter.js library is an easy way 
 
 * [Concepts in epicenter.js](#concepts)
 * [Using epicenter.js](#using-epicenter-js)
-    * [Including](#include)
-    * [Accessing](#access)
-    * [Examples of usage: Callbacks and promises](#example)
-    * [Configuration options](#configuration)
+	* [Including](#include)
+	* [Accessing](#access)
+	* [Examples of usage: Callbacks and promises](#example)
+	* [Configuration options](#configuration)
 
 
 <a name="concepts"></a>
-###Concepts in epicenter.js
+###Concepts in Epicenter.js
 
 The epicenter.js library is a set of services and managers to help streamline your work with the underlying Epicenter APIs.
 
 * The [Run Service](./generated/run-api-service/), [Data Service](./generated/data-api-service/), [Auth Service](./generated/auth-api-service), and [Variables Service](./generated/variables-api-service/) are direct adaptations of the underlying [Run](../aggregate_run_api/), [Data](../data_api/), [Authentication](../project_access/), and [Variable](../model_apis/variable/) RESTful APIs.
 
-* The [Run Manager](./generated/run-manager/) adds functionality on top of the Run Service. Specifically, the Run Manager gives you control over run creation depending on run state. You can select run creation [strategies](./strategy/) (rules) for which runs end users of your project work with when they log in to your project.
+* The [Run Manager](./generated/run-manager/) adds functionality on top of the Run Service. Specifically, the Run Manager gives you control over run creation depending on run state. You can select run creation [strategies](./strategy/) (rules) for which runs end users of your project work with when they log in to your project. 
 
 
 <a name="using-epicenter-js"></a>
-###Using epicenter.js
+###Using Epicenter.js
 
 <a name="include"></a>
 ####Including
-The epicenter.js library is available from our CDN: [cdn-common.forio.com/js-libs/1.1.2/epicenter.min.js](https://cdn-common.forio.com/js-libs/1.1.2/epicenter.min.js). To use it in your project, simply add
+The epicenter.js library is available from our tools: <a href="https://forio.com/tools/js-libs/1.1.2/epicenter.min.js" target="_blank">https://forio.com/tools/js-libs/1.1.2/epicenter.min.js</a>. To use it in your project, simply add
 
-    <script src="https://cdn-common.forio.com/js-libs/1.1.2/epicenter.min.js"></script>
+    <script src="https://forio.com/tools/js-libs/1.1.2/epicenter.min.js"></script>
 
 into any of your [interface](../creating_your_interface/) files (e.g. .html and .js files).
 
@@ -54,7 +54,7 @@ For example:
     var rm = new F.service.RunManager();
 
 <a name="example"></a>
-####Examples of usage: Callbacks and Promises
+####Examples of Usage: Callbacks and Promises
 
 There are two different patterns for using the service adapters: using callbacks or using promises.
 
@@ -70,19 +70,19 @@ All services take in an ["options" configuration object](#configuration) as the 
 For example, you might write a sequence of operations using callbacks:
 
     var rm = new F.service.RunManager({
-        run: {
-            account: 'myTeamId',
-            project: 'sales_forecaster',
-            model: 'sales_forecaster.jl'
+    	run: {
+        	account: 'myTeamId',
+        	project: 'sales_forecaster',
+        	model: 'sales_forecaster.jl'
         }
     });
     rm.getRun({
         success: function() {
             rm.getRun(function(run) {
-                run.serial(
-                    ['initialize_inputs', 'calculate_input_totals', 'forecast_monthly_profit'],
-                    null,
-                    { success: function(data) {
+            	run.serial(
+            		['initialize_inputs', 'calculate_input_totals', 'forecast_monthly_profit'], 
+            		null, 
+            		{ success: function(data) {
                         displayUI(data, function () {
                             hideLoadingScreen(function () {
                                 run.variables().load('profit_histogram');
@@ -92,7 +92,7 @@ For example, you might write a sequence of operations using callbacks:
                       error: function() {
                         console.log('Oops! Something went wrong with the operations');
                       }
-                    }
+                	}
                 )
             });
         }
@@ -102,7 +102,7 @@ Callbacks work well for one-off operations, but can become difficult to follow w
 
 **Promises**
 
-Every service call returns a promise. All services support the [jQuery Deferred Object functions](http://api.jquery.com/category/deferred-object/), including the following most common functions:
+Every service call returns a promise. All services support the <a href="http://api.jquery.com/category/deferred-object/" target="_blank">jQuery Deferred Object functions</a>, including the following most common functions:
 
 * `then`: Add handlers to be called when the object is resolved, rejected, or still in progress
 * `done`: Add handlers to be called when the object is resolved
@@ -110,30 +110,30 @@ Every service call returns a promise. All services support the [jQuery Deferred 
 
 For example, you might write the same sequence of operations as above using promises:
 
-    var rm = new F.service.RunManager({
-        run: {
-            account: 'myTeamId',
-            project: 'sales_forecaster',
-            model: 'sales_forecaster.jl'
-        }
-    });
-    rm.getRun()
-        .then(function(run) {
-            run.serial(['initialize_inputs', 'calculate_input_totals', 'forecast_monthly_profit'])
-                .then(displayUI)
-                .then(hideLoadingScreen)
-                .then(function () {
-                    run.variables().load('profit_histogram');
-                })
-                .fail(function() {
-                    console.log('Oops! Something went wrong with the operations');
-                });
-        });
+	var rm = new F.service.RunManager({
+		run: {
+		    account: 'myTeamId',
+	    	project: 'sales_forecaster',
+	    	model: 'sales_forecaster.jl'
+	    }
+	});
+	rm.getRun()
+	    .then(function(run) {
+	        run.serial(['initialize_inputs', 'calculate_input_totals', 'forecast_monthly_profit'])
+	            .then(displayUI)
+	            .then(hideLoadingScreen)
+	            .then(function () {
+	                run.variables().load('profit_histogram');
+	            })
+	            .fail(function() {
+	                console.log('Oops! Something went wrong with the operations');
+	            });
+	    });
 
-See for example [this blog](http://blog.parse.com/2013/01/29/whats-so-great-about-javascript-promises/) for more background on how promises work in JavaScript.
+See for example <a href="http://blog.parse.com/2013/01/29/whats-so-great-about-javascript-promises/" target="_blank">this blog</a> for more background on how promises work in JavaScript.
 
 <a name="configuration"></a>
-####Configuration options
+####Configuration Options
 
 Every service takes in a configuration options object as the last parameter. This optional parameter allows you to override any of the default configuration options.
 

--- a/src/service/run-api-service.js
+++ b/src/service/run-api-service.js
@@ -254,7 +254,7 @@ module.exports = function (config) {
         /**
          * Call a method from the model.
          *
-         * The method must be exposed (e.g. `export` for a Julia model, see [Writing your Model](../../../writing_your_model/)) in the model file in order to be called through the API.
+         * Depending on the language in which you have written your model, the method may need to be exposed (e.g. `export` for a Julia model) in the model file in order to be called through the API. See [Writing your Model](../../../writing_your_model/)).
          *
          * The `params` argument is normally an array of arguments to the `operation`. In the special case where `operation` only takes one argument, you are not required to put that argument into an array.
          *
@@ -307,7 +307,7 @@ module.exports = function (config) {
         /**
          * Call several methods from the model, sequentially.
          *
-         * The methods must be exposed (e.g. `export` for a Julia model, see [Writing your Model](../../../writing_your_model/)) in the model file in order to be called through the API.
+         * Depending on the language in which you have written your model, the methods may need to be exposed (e.g. `export` for a Julia model) in the model file in order to be called through the API. See [Writing your Model](../../../writing_your_model/)).
          *
          * **Examples**
          *
@@ -362,7 +362,7 @@ module.exports = function (config) {
         /**
          * Call several methods from the model, executing them in parallel.
          *
-         * The methods must be exposed (e.g. `export` for a Julia model, see [Writing your Model](../../../writing_your_model/)) in the model file in order to be called through the API.
+         * Depending on the language in which you have written your model, the methods may need to be exposed (e.g. `export` for a Julia model) in the model file in order to be called through the API. See [Writing your Model](../../../writing_your_model/)).
          *
          * **Example**
          *


### PR DESCRIPTION
these were already merged into master in the Epicenter project, but current process is manual syncing of epicenter-js-libs and epicenter for docs work.