### PR TITLE
pick group from instance during create call

### DIFF
--- a/src/service/world-api-adapter.js
+++ b/src/service/world-api-adapter.js
@@ -98,7 +98,7 @@ module.exports = function (config) {
             }
 
             // account and project go in the body, not in the url
-            $.extend(params, _pick(serviceOptions, ['account', 'project']));
+            $.extend(params, _pick(serviceOptions, ['account', 'project', 'group']));
 
             var oldSuccess = createOptions.success;
             createOptions.success = function (response) {


### PR DESCRIPTION
per diagnosis by Jaime.
we want to call `var gm = new F.service.World` with group, so that gm
has group available (and things like gm.list() work without error). so
need create() to pick group also.