### PR TITLE
fix broken url regex for matching account and project in login.js

### DIFF
--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -9,7 +9,7 @@ $(function () {
 
     var getAccountProjectFromUrl = function () {
         var url = window.location.href;
-        var parts = url.match(/https?:\/\/(.*)\/app\/(.*)\/(.*)/gi) || [];
+        var parts = url.match(/https?:\/\/([^/]*)\/app\/([^/]*)\/([^/]*)/) || [];
         return {
             account: parts[2],
             project: parts[3]


### PR DESCRIPTION
In login.js, `getAccountProjectFromUrl()` had a problem with its regular expression that caused it to never find the account and project in the url, always falling back to the account and project specified in hidden fields in the form.

This fix is a correction to the regex. The account and project will be taken from hidden fields in the form first, and if they're not found, it will fall back to the url.