### PR TITLE
EPICENTER-1725: Load the api configuration from the server

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,9 @@ var F = {
 
 };
 
+F.load = require('./env-load');
+F.load();
+
 F.util.query = require('./util/query-util');
 F.util.makeSequence = require('./util/make-sequence');
 F.util.run = require('./util/run-util');
@@ -55,8 +58,6 @@ F.manager.strategy['new-if-initialized'] = require('./managers/run-strategies/ne
 
 F.manager.ChannelManager = require('./managers/epicenter-channel-manager');
 F.service.Channel = require('./service/channel-service');
-
-F.load = require('./env-load');
 
 F.version = '<%= version %>';
 F.api = require('./api-version.json');

--- a/src/app.js
+++ b/src/app.js
@@ -56,6 +56,8 @@ F.manager.strategy['new-if-initialized'] = require('./managers/run-strategies/ne
 F.manager.ChannelManager = require('./managers/epicenter-channel-manager');
 F.service.Channel = require('./service/channel-service');
 
+F.load = require('./env-load');
+
 F.version = '<%= version %>';
 F.api = require('./api-version.json');
 

--- a/src/env-load.js
+++ b/src/env-load.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var urlConfigService = require('./service/url-config-service');
+
+var envLoad = function (callback) {
+    var envPromise;
+    var host;
+    var urlService = urlConfigService();
+    var envPath = '/epicenter/v1/config';
+    if (urlService.isLocalhost()) {
+        envPromise = $.Deferred();
+        envPromise.resolve();
+        host = 'https://forio.com';
+    } else {
+        host = '';
+    }
+    var infoUrl = host + envPath;
+    envPromise = $.ajax(infoUrl);
+    envPromise.done(function (res) {
+        var api = res.api;
+        $.extend(urlConfigService, api);
+    });
+    envPromise.done(callback).fail(callback);
+};
+
+module.exports = envLoad;

--- a/src/env-load.js
+++ b/src/env-load.js
@@ -15,7 +15,7 @@ var envLoad = function (callback) {
         host = '';
     }
     var infoUrl = host + envPath;
-    envPromise = $.ajax(infoUrl);
+    envPromise = $.ajax({ url: infoUrl, async: false });
     envPromise.done(function (res) {
         var api = res.api;
         $.extend(urlConfigService, api);

--- a/src/service/url-config-service.js
+++ b/src/service/url-config-service.js
@@ -2,7 +2,7 @@
 
 var epiVersion = require('../api-version.json');
 
-module.exports = function (config) {
+var UrlConfigService = function (config) {
     //TODO: urlutils to get host, since no window on node
 
     var API_PROTOCOL = 'https';
@@ -70,6 +70,14 @@ module.exports = function (config) {
         }
     };
 
-    $.extend(publicExports, config);
+    // This data is set by an external script (start-load.js)
+    var envConf = {
+        protocol: UrlConfigService.protocol,
+        host: UrlConfigService.host
+    };
+
+    $.extend(publicExports, envConf, config);
     return publicExports;
 };
+
+module.exports = UrlConfigService;

--- a/tests/index.html
+++ b/tests/index.html
@@ -87,6 +87,7 @@
     <script src="spec/test-channel-service.js"></script>
     <script src="spec/test-channel-manager.js"></script>
     <script src="spec/test-epicenter-channel-manager.js"></script>
+    <script src="spec/test-env-load.js"></script>
 
     <script>
     // If tests run in a real browser

--- a/tests/spec/test-env-load.js
+++ b/tests/spec/test-env-load.js
@@ -1,0 +1,47 @@
+(function () {
+    'use strict';
+    describe('Env Load', function () {
+        var server;
+        beforeEach(function () {
+            server = sinon.fakeServer.create();
+
+            var env = {
+                api: {
+                    host: 'api.forio.com',
+                    protocol: 'https'
+                }
+            };
+            // API Config
+            server.respondWith('GET', /forio\.com\/epicenter\/v1\/config/, function (xhr, id) {
+                xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(env));
+            });
+
+            server.autoRespond = true;
+        });
+
+        afterEach(function () {
+            server.restore();
+        });
+
+        describe('load', function () {
+            it('it should request the server env url', function () {
+                F.load();
+
+                var req = server.requests.pop();
+                req.method.toUpperCase().should.equal('GET');
+                req.url.should.equal('https://forio.com/epicenter/v1/config');
+            });
+
+            it('it should set protocol and host to the UrlConfingService', function () {
+                delete F.service.URL.protocol;
+                delete F.service.URL.host;
+                F.load(function () {
+                    F.service.URL.protocol.should.equal('https');
+                    F.service.URL.host.should.equal('api.forio.com');
+                    delete F.service.URL.protocol;
+                    delete F.service.URL.host;
+                });
+            });
+        });
+    });
+})();

--- a/tests/spec/test-url-config-service.js
+++ b/tests/spec/test-url-config-service.js
@@ -26,6 +26,17 @@
                 var url = new URLService({ accountPath: 'forioAccount', projectPath: 'forioProj', versionPath: '' });
                 url.getAPIPath('data').should.equal('https://api.forio.com/data/forioAccount/forioProj/');
             });
+
+            it('should allow over-riding host and protocol globally', function () {
+                URLService.protocol = 'htttps';
+                URLService.host = 'funky.forio.com';
+                var url = new URLService({ accountPath: 'forioAccount', projectPath: 'forioProj', versionPath: '' });
+                url.getAPIPath('data').should.equal('htttps://funky.forio.com/data/forioAccount/forioProj/');
+
+                // Delete global settings to avoid affecting other tests
+                delete F.service.URL.protocol;
+                delete F.service.URL.host;
+            });
         });
     });
 })();


### PR DESCRIPTION
Added a few tests, seem to be working fine. F.load() gets called at the start and the request is synchronous so all calls will have the server configuration loaded before use.