### PR TITLE
Feature/file replace flag

### DIFF
--- a/src/service/admin-file-service.js
+++ b/src/service/admin-file-service.js
@@ -128,29 +128,21 @@ module.exports = function (config) {
          * Creates a file in the given file path.
          * @param  {String} `filePath` Path to the file
          * @param  {String} `contents` Contents to write to file
+         * @param  {Boolean} `replaceExisting` Replace file if it already exists; defaults to false
          * @param  {Object} `options`  (Optional) Overrides for configuration options
          */
-        create: function (filePath, contents, options) {
+        create: function (filePath, contents, replaceExisting, options) {
             var httpOptions = uploadFileOptions(filePath, contents, options);
-
-            return http.post(httpOptions.data, httpOptions);
-        },
-
-        /**
-         * Uploads a file to the given path. It will try to create the file and if there's a conflict error (409) it will try to replace the file instead.
-         * @param  {String} `filePath` Path to the file
-         * @param  {String} `contents` Contents to write to file
-         * @param  {Object} `options`  (Optional) Overrides for configuration options
-         */
-        upload: function (filePath, contents, options) {
-            var self = this;
-
-            return this.create(filePath, contents, options)
-                .then(null, function (xhr) {
+            var prom = http.post(httpOptions.data, httpOptions);
+            var me = this;
+            if (replaceExisting === true) {
+                prom = prom.then(null, function (xhr) {
                     if (xhr.status === 409) {
-                        return self.replace(filePath, contents, options);
+                        return me.replace(filePath, contents, options);
                     }
                 });
+            }
+            return prom;
         },
 
         /**

--- a/src/service/admin-file-service.js
+++ b/src/service/admin-file-service.js
@@ -161,7 +161,7 @@ module.exports = function (config) {
         /**
          * Renames the file.
          * @param  {String} filePath Path to the file
-         * @param  {Stirng} newName  New name of file
+         * @param  {String} newName  New name of file
          * @param  {Object} options  (Optional) Overrides for configuration options
          */
         rename: function (filePath, newName, options) {

--- a/tests/spec/test-admin-file-service.js
+++ b/tests/spec/test-admin-file-service.js
@@ -129,9 +129,6 @@
                 req.requestBody.should.include('test.html');
             });
             it('should overwrite if file is present and `replaceExisting` is set', function (done) {
-                var fs = new FileService({ account: account, project: projectUpload, folderType: 'static' });
-                fs.create('test.html', '<html></html>', true);
-                
                 server.requests = [];
                 var fs = new FileService({ account: account, project: projectUpload, folderType: 'static' });
                 fs.create('existing.html', '<html></html>', true).then(function () {

--- a/tests/spec/test-admin-file-service.js
+++ b/tests/spec/test-admin-file-service.js
@@ -122,43 +122,23 @@
                 var content = '<html></html>';
                 var fs = new FileService({ account: account, project: projectUpload, folderType: 'static' });
                 fs.create('test.html', content);
+                server.requests.should.have.lengthOf(2);
 
                 var req = server.requests.pop();
                 req.requestBody.should.include(content);
                 req.requestBody.should.include('test.html');
             });
-        });
-        describe('#upload', function () {
-            it('Should do a POST only', function () {
+            it('should overwrite if file is present and `replaceExisting` is set', function (done) {
                 var fs = new FileService({ account: account, project: projectUpload, folderType: 'static' });
-                fs.upload('new.html', '<html></html>');
-
-                var req = server.requests.pop();
-                req.method.toUpperCase().should.equal('POST');
-            });
-
-            it('Should do a POST and PUT after it fails', function (done) {
+                fs.create('test.html', '<html></html>', true);
+                
                 server.requests = [];
                 var fs = new FileService({ account: account, project: projectUpload, folderType: 'static' });
-                fs.upload('existing.html', '<html></html>').then(function () {
+                fs.create('existing.html', '<html></html>', true).then(function () {
                     server.requests.should.have.lengthOf(2);
                     var req = server.requests.pop();
                     req.method.toUpperCase().should.equal('PUT');
                     req = server.requests.pop();
-                    req.method.toUpperCase().should.equal('POST');
-                    done();
-                }, function () {
-                    done(new Error('Should not fail'));
-                });
-            });
-
-            it('Should only do a POST', function (done) {
-                server.requests = [];
-                var fs = new FileService({ account: account, project: projectUpload, folderType: 'static' });
-
-                fs.upload('new.html', '<html></html>').then(function () {
-                    server.requests.should.have.lengthOf(1);
-                    var req = server.requests.pop();
                     req.method.toUpperCase().should.equal('POST');
                     done();
                 }, function () {


### PR DESCRIPTION
`create` and `upload` were pretty much the same thing, except 1 replaced the file if it existed and the other didn't. I could never remember which is which. I deleted `upload` and gave `create` and option to override files instead.