### PR TITLE
Chore/deprecation notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ This mirrors getting it through `F.manager.strategy` - this endpoint is now cons
 
 This interface now introduces a new way to 'register' named run strategies for use with the Run Manager. <See jsdocs for strategies/index.js for more info>. Note you can still by-pass registering by calling the RunManager with a function, i.e., `new F.manager.RunManager({ strategy: function(){}})`, so this is a backwards compatible change which just additionally allows naming.  
 
+### Bug fixes
+#### Run Manager's current instance of the run is always valid/up-to-date.
+The 'current run service' of the run manager can be access through `rm.run`; however this was buggy before. For instance
+```
+    var rm = new F.manager.RunManager();
+    var id = rm.run.getCurrentConfig().id; //assume id 1
+    rm.reset().then(function () {
+        var newid = rm.run.getCurrentConfig().id; //should be 2 but used to return 1 before
+    })
+```
+
+### `runService.query` and `runService.filter` return empty arrays for no results.
+Due to a quirk in the platform `runService.query` used to return an array of runs if it found any, or an empty _Object_ ({}), if none existed. They now correctly return empty arrays instead.
 
 <a name="2.0.1"></a>
 ### 2.0.1 (2016-11-18)

--- a/src/managers/run-manager.js
+++ b/src/managers/run-manager.js
@@ -138,9 +138,11 @@ RunManager.prototype = {
      *          rm.run.do('runModel');
      *      });
      *
+     * @param {Array} variables (Optional) if provided it'll populate the run it gets with the provided variables.
+     * @param {Object} options (Optional) these will be passed on to RunService#create if the strategy does create a new run
      * @return {$promise} Promise to complete the call.
      */
-    getRun: function (variables) {
+    getRun: function (variables, options) {
         var me = this;
         var sessionStore = this.sessionManager.getStore();
         var runSession = JSON.parse(sessionStore.get(this.options.sessionKey) || '{}');
@@ -152,7 +154,7 @@ RunManager.prototype = {
             return $.Deferred().reject('No user-session available').promise();
         }
         return this.strategy
-                .getRun(this.run, authSession, runid).then(function (run) {
+                .getRun(this.run, authSession, runid, options).then(function (run) {
                     if (run && run.id) {
                         setRunInSession(me.options.sessionKey, run.id, me.sessionManager);
                         me.run.updateConfig({ filter: run.id });

--- a/src/managers/run-manager.js
+++ b/src/managers/run-manager.js
@@ -195,20 +195,12 @@ RunManager.prototype = {
             console.error('No user-session available', this.options.strategy, 'requires authentication.');
             return $.Deferred().reject('No user-session available').promise();
         }
-        return this.strategy.reset(this.run, authSession).then(function (run) {
+        return this.strategy.reset(this.run, authSession, options).then(function (run) {
             if (run && run.id) {
                 setRunInSession(me.options.sessionKey, run.id, me.sessionManager);
                 me.run.updateConfig({ filter: run.id });
-
-                if (options && options.success) {
-                    options.success(run);
-                }
             }
             return run;
-        }, function (err) {
-            if (options && options.error) {
-                options.error(err);
-            }
         });
     }
 };

--- a/src/managers/run-manager.js
+++ b/src/managers/run-manager.js
@@ -188,7 +188,7 @@ RunManager.prototype = {
      * **Parameters**
      * @return {Promise}
      */
-    reset: function () {
+    reset: function (options) {
         var me = this;
         var authSession = this.sessionManager.getSession();
         if (this.strategy.requiresAuth && util.isEmpty(authSession)) {
@@ -199,8 +199,16 @@ RunManager.prototype = {
             if (run && run.id) {
                 setRunInSession(me.options.sessionKey, run.id, me.sessionManager);
                 me.run.updateConfig({ filter: run.id });
+
+                if (options && options.success) {
+                    options.success(run);
+                }
             }
             return run;
+        }, function (err) {
+            if (options && options.error) {
+                options.error(err);
+            }
         });
     }
 };

--- a/src/managers/run-strategies/conditional-creation-strategy.js
+++ b/src/managers/run-strategies/conditional-creation-strategy.js
@@ -12,7 +12,6 @@ var classFrom = require('../../util/inherit');
 var Strategy = classFrom(Base, {
     constructor: function Strategy(condition) {
         if (condition == null) { //eslint-disable-line
-            //TODO: not sure why this is explicitly ==
             throw new Error('Conditional strategy needs a condition to create a run');
         }
         this.condition = typeof condition !== 'function' ? function () { return condition; } : condition;
@@ -40,7 +39,7 @@ var Strategy = classFrom(Base, {
     },
 
     /**
-     * Gets the 'correct' run (the definition of 'currect' depends on strategy implementation)
+     * Gets the 'correct' run (the definition of 'correct' depends on strategy implementation)
      * @param  {RunService} runService  a Run Service instance for the 'current run' as determined by the Run Manager
      * @param  {Object} userSession Information about the current user seesion. See AuthManager#getCurrentUserSession for format
      * @param  {String} runIdInSession the RunManager stores the 'last accessed' run in a cookie;  this refers to the last-used runid

--- a/src/managers/run-strategies/conditional-creation-strategy.js
+++ b/src/managers/run-strategies/conditional-creation-strategy.js
@@ -22,16 +22,17 @@ var Strategy = classFrom(Base, {
      * Resets current run
      * @param  {RunService} runService  a Run Service instance for the 'current run' as determined by the Run Manager
      * @param  {Object} userSession Information about the current user seesion. See AuthManager#getCurrentUserSession for format
+     * @param  {Object} options (Optional) See RunService#create for supported options
      * @return {Promise}             
      */
-    reset: function (runService, userSession) {
+    reset: function (runService, userSession, options) {
         var group = userSession && userSession.groupName;
         var opt = $.extend({
             scope: { group: group }
         }, runService.getCurrentConfig());
 
         return runService
-                .create(opt)
+                .create(opt, options)
                 .then(function (run) {
                     run.freshlyCreated = true;
                     return run;
@@ -43,20 +44,21 @@ var Strategy = classFrom(Base, {
      * @param  {RunService} runService  a Run Service instance for the 'current run' as determined by the Run Manager
      * @param  {Object} userSession Information about the current user seesion. See AuthManager#getCurrentUserSession for format
      * @param  {String} runIdInSession the RunManager stores the 'last accessed' run in a cookie;  this refers to the last-used runid
+     * @param  {Object} options (Optional) See RunService#create for supported options
      * @return {Promise}             
      */
-    getRun: function (runService, userSession, runIdInSession) {
+    getRun: function (runService, userSession, runIdInSession, options) {
         var me = this;
         if (runIdInSession) {
-            return this.loadAndCheck(runService, userSession, runIdInSession).catch(function () {
-                return me.reset(runService, userSession); //if it got the wrong cookie for e.g.
+            return this.loadAndCheck(runService, userSession, runIdInSession, options).catch(function () {
+                return me.reset(runService, userSession, options); //if it got the wrong cookie for e.g.
             });
         } else {
-            return this.reset(runService, userSession);
+            return this.reset(runService, userSession, options);
         }
     },
 
-    loadAndCheck: function (runService, userSession, runIdInSession) {
+    loadAndCheck: function (runService, userSession, runIdInSession, options) {
         var shouldCreate = false;
         var me = this;
 
@@ -68,7 +70,7 @@ var Strategy = classFrom(Base, {
             })
             .then(function (run) {
                 if (shouldCreate) {
-                    return me.reset(runService, userSession);
+                    return me.reset(runService, userSession, options);
                 }
                 return run;
             });

--- a/src/managers/run-strategies/index.js
+++ b/src/managers/run-strategies/index.js
@@ -1,6 +1,6 @@
 var list = {
-    'new-if-initialized': require('./new-if-initialized-strategy'),
-    'new-if-persisted': require('./new-if-persisted-strategy'),
+    'new-if-initialized': require('./new-if-initialized-strategy'), //deprecated
+    'new-if-persisted': require('./new-if-persisted-strategy'), //deprecated
     'new-if-missing': require('./new-if-missing-strategy'),
     'always-new': require('./always-new-strategy'),
     multiplayer: require('./multiplayer-strategy'),

--- a/src/managers/run-strategies/new-if-initialized-strategy.js
+++ b/src/managers/run-strategies/new-if-initialized-strategy.js
@@ -23,6 +23,7 @@ var __super = ConditionalStrategy.prototype;
 var Strategy = classFrom(ConditionalStrategy, {
     constructor: function (options) {
         __super.constructor.call(this, this.createIf, options);
+        console.warn('This strategy is deprecated; all runs now default to being initialized by default making this redundant');
     },
 
     createIf: function (run, headers) {

--- a/src/managers/run-strategies/new-if-persisted-strategy.js
+++ b/src/managers/run-strategies/new-if-persisted-strategy.js
@@ -26,6 +26,7 @@ var __super = ConditionalStrategy.prototype;
 var Strategy = classFrom(ConditionalStrategy, {
     constructor: function (options) {
         __super.constructor.call(this, this.createIf, options);
+        console.warn('This strategy is deprecated; the run-service now sets a header to automatically bring back runs into memory');
     },
 
     createIf: function (run, headers) {

--- a/src/managers/run-strategies/persistent-single-player-strategy.js
+++ b/src/managers/run-strategies/persistent-single-player-strategy.js
@@ -25,32 +25,33 @@ var Strategy = classFrom(IdentityStrategy, {
         this.stateApi = new StateApi();
     },
 
-    reset: function (runService, userSession) {
+    reset: function (runService, userSession, options) {
         var group = userSession.groupName;
         var opt = $.extend({
             scope: { group: group }
         }, runService.getCurrentConfig());
         return runService
-            .create(opt)
+            .create(opt, options)
             .then(function (run) {
                 run.freshlyCreated = true;
                 return run;
             });
     },
 
-    getRun: function (runService, userSession) {
+    getRun: function (runService, userSession, runIdInSession, options) {
         var me = this;
+        //FIXME: this should only load 'last run' into memory
         return runService.query({
             'user.id': userSession.userId || '0000',
             'scope.group': userSession.groupName
         }).then(function (runs) {
-            return me._loadAndCheck(runService, userSession, runs);
+            return me._loadAndCheck(runService, userSession, runs, options);
         });
     },
 
-    _loadAndCheck: function (runService, userSession, runs) {
+    _loadAndCheck: function (runService, userSession, runs, options) {
         if (!runs || !runs.length) {
-            return this.reset(runService, userSession);
+            return this.reset(runService, userSession, options);
         }
 
         var dateComp = function (a, b) { return new Date(b.date) - new Date(a.date); };

--- a/tests/spec/test-run-manager.js
+++ b/tests/spec/test-run-manager.js
@@ -419,6 +419,26 @@
                     expect(config.id).to.equal(runid);
                 });
             });
+            describe.only('When used as an operation', function () {
+                var resetStub;
+                beforeEach(function () {
+                    resetStub = sinon.stub(rm, 'reset').returns($.Deferred().resolve().promise());
+                });
+                afterEach(function () {
+                    resetStub.restore();
+                });
+                it('should patch `do` function of the run service to call the strategy reset', function () {
+                    return rm.run.do('reset').then(function () {
+                        expect(resetStub).to.have.been.calledOnce;
+                    });
+                });
+                it('should pass on reset options', function () {
+                    var options = { success: 'yay' };
+                    return rm.run.do('reset', null, options).then(function () {
+                        expect(resetStub).to.have.been.calledWith(options);
+                    });
+                });
+            });
         });
     });
 }());

--- a/tests/spec/test-run-manager.js
+++ b/tests/spec/test-run-manager.js
@@ -419,7 +419,7 @@
                     expect(config.id).to.equal(runid);
                 });
             });
-            describe.only('When used as an operation', function () {
+            describe('When used as an operation', function () {
                 var resetStub;
                 beforeEach(function () {
                     resetStub = sinon.stub(rm, 'reset').returns($.Deferred().resolve().promise());


### PR DESCRIPTION
Some strategies are now redundant with API changes made since. Add deprecation note now, and officially remove 2-3 versions out.

(merge once we update the docs to match)