### PR TITLE
Chore/deprecation notices

### DIFF
--- a/src/managers/run-manager.js
+++ b/src/managers/run-manager.js
@@ -90,7 +90,7 @@ var defaults = {
      * Run creation strategy for when to create a new run and when to reuse an end user's existing run. See [Run Manager Strategies](../strategies/) for details. Defaults to `new-if-initialized`.
      * @type {String}
      */
-    strategy: 'new-if-initialized'
+    strategy: 'new-if-missing'
 };
 
 function RunManager(options) {

--- a/src/managers/run-manager.js
+++ b/src/managers/run-manager.js
@@ -87,7 +87,7 @@ var defaults = {
     sessionKey: keyNames.STRATEGY_SESSION_KEY,
 
     /**
-     * Run creation strategy for when to create a new run and when to reuse an end user's existing run. See [Run Manager Strategies](../strategies/) for details. Defaults to `new-if-initialized`.
+     * Run creation strategy for when to create a new run and when to reuse an end user's existing run. See [Run Manager Strategies](../strategies/) for details. Defaults to `new-if-missing`.
      * @type {String}
      */
     strategy: 'new-if-missing'

--- a/src/managers/run-strategies/conditional-creation-strategy.js
+++ b/src/managers/run-strategies/conditional-creation-strategy.js
@@ -12,7 +12,6 @@ var classFrom = require('../../util/inherit');
 var Strategy = classFrom(Base, {
     constructor: function Strategy(condition) {
         if (condition == null) { //eslint-disable-line
-            //TODO: not sure why this is explicitly ==
             throw new Error('Conditional strategy needs a condition to create a run');
         }
         this.condition = typeof condition !== 'function' ? function () { return condition; } : condition;
@@ -40,7 +39,7 @@ var Strategy = classFrom(Base, {
     },
 
     /**
-     * Gets the 'correct' run (the definition of 'currect' depends on strategy implementation)
+     * Gets the 'correct' run (the definition of 'correct' depends on strategy implementation)
      * @param  {RunService} runService  a Run Service instance for the 'current run' as determined by the Run Manager
      * @param  {Object} userSession Information about the current user seesion. See AuthManager#getCurrentUserSession for format
      * @param  {String} runIdInSession the RunManager stores the 'last accessed' run in a cookie;  this refers to the last-used runid

--- a/src/managers/run-strategies/index.js
+++ b/src/managers/run-strategies/index.js
@@ -1,6 +1,6 @@
 var list = {
-    'new-if-initialized': require('./new-if-initialized-strategy'),
-    'new-if-persisted': require('./new-if-persisted-strategy'),
+    'new-if-initialized': require('./new-if-initialized-strategy'), //deprecated
+    'new-if-persisted': require('./new-if-persisted-strategy'), //deprecated
     'new-if-missing': require('./new-if-missing-strategy'),
     'always-new': require('./always-new-strategy'),
     multiplayer: require('./multiplayer-strategy'),

--- a/src/managers/run-strategies/new-if-initialized-strategy.js
+++ b/src/managers/run-strategies/new-if-initialized-strategy.js
@@ -23,6 +23,7 @@ var __super = ConditionalStrategy.prototype;
 var Strategy = classFrom(ConditionalStrategy, {
     constructor: function (options) {
         __super.constructor.call(this, this.createIf, options);
+        console.warn('This strategy is deprecated; all runs now default to being initialized by default making this redundant');
     },
 
     createIf: function (run, headers) {

--- a/src/managers/run-strategies/new-if-initialized-strategy.js
+++ b/src/managers/run-strategies/new-if-initialized-strategy.js
@@ -1,4 +1,6 @@
 /**
+ * **This strategy is deprecated; all runs now default to being initialized at run creation, making this redundant.**
+ *
  * The `new-if-initialized` strategy creates a new run if the current one is in memory or has its `initialized` field set to `true`. The `initialized` field in the run record is automatically set to `true` at run creation for Vensim models; it can be set manually for other models.
  * 
  * This strategy is useful if your project is structured such that immediately after a run is created, the model is executed completely (for example, a Vensim model is stepped to the end). It is similar to the `new-if-missing` strategy, except that it checks a field of the run record.

--- a/src/managers/run-strategies/new-if-persisted-strategy.js
+++ b/src/managers/run-strategies/new-if-persisted-strategy.js
@@ -1,4 +1,6 @@
 /**
+ * **This strategy is deprecated; the [Run Service](../run-api-service/) now sets a header to automatically bring back runs into memory.** (See `autoRestore` under the Run Service Configuration Options for additional information.)
+ * 
  * The `new-if-persisted` strategy creates a new run when the current one becomes persisted (end user is idle for a set period), but otherwise uses the current one. 
  * 
  * Using this strategy means that when end users navigate between pages in your project, or refresh their browsers, they will still be working with the same run. 

--- a/src/managers/run-strategies/new-if-persisted-strategy.js
+++ b/src/managers/run-strategies/new-if-persisted-strategy.js
@@ -26,6 +26,7 @@ var __super = ConditionalStrategy.prototype;
 var Strategy = classFrom(ConditionalStrategy, {
     constructor: function (options) {
         __super.constructor.call(this, this.createIf, options);
+        console.warn('This strategy is deprecated; the run-service now sets a header to automatically bring back runs into memory');
     },
 
     createIf: function (run, headers) {


### PR DESCRIPTION
Some strategies are now redundant with API changes made since. Add deprecation note now, and officially remove 2-3 versions out.

(merge once we update the docs to match)