### PR TITLE
TEMPLATE-462 Create new run if received run is trashed for certain run strategies

### DIFF
--- a/src/managers/run-strategies/reuse-across-sessions.js
+++ b/src/managers/run-strategies/reuse-across-sessions.js
@@ -8,7 +8,7 @@ import { injectFiltersFromSession, injectScopeFromSession } from 'managers/run-s
  * This strategy is useful if end users are using your project for an extended period of time, possibly over several sessions. This is most common in cases where a user of your project executes the model step by step (as opposed to a project where the model is executed completely, for example, a Vensim model that is immediately stepped to the end).
  *
  * Specifically, the strategy is:
- * 
+ *
  * * Check if there are any runs for this end user.
  *     * If there are no runs (either in memory or in the database), create a new one.
  *     * If there are runs, take the latest (most recent) one.
@@ -39,13 +39,14 @@ const Strategy = classFrom(IdentityStrategy, {
 
     getRun: function (runService, userSession, runSession, options) {
         const filter = injectFiltersFromSession(this.options.filter, userSession);
-        return runService.query(filter, { 
+        return runService.query(filter, {
             startrecord: 0,
             endrecord: 0,
-            sort: 'created', 
+            sort: 'created',
             direction: 'desc'
         }).then((runs)=> {
-            if (!runs.length) {
+            if (!runs.length || runs[0].trashed) {
+                // If no runs exist or the most recent run is trashed, create a new run
                 return this.reset(runService, userSession, options);
             }
             return runs[0];

--- a/src/managers/run-strategies/reuse-last-initialized.js
+++ b/src/managers/run-strategies/reuse-last-initialized.js
@@ -75,11 +75,12 @@ export default class ReuseLastInitializedStrategy {
             sort: 'created',
             direction: 'desc'
         }).then((runs)=> {
-            if (!runs.length || runs[0].trashed) {
+            const latestActiveRun = (runs || []).find((run)=> !run.trashed);
+            if (!runs.length || !latestActiveRun) {
                 // If no runs exist or the most recent run is trashed, create a new run
                 return this.reset(runService, userSession, options);
             }
-            return runs[0];
+            return latestActiveRun;
         });
     }
 }

--- a/src/managers/run-strategies/reuse-last-initialized.js
+++ b/src/managers/run-strategies/reuse-last-initialized.js
@@ -1,7 +1,7 @@
 import { injectFiltersFromSession, injectScopeFromSession } from 'managers/run-strategies/strategy-utils';
 
 /**
- * The `reuse-last-initialized` strategy looks for the most recent run that matches particular criteria; if it cannot find one, it creates a new run and immediately executes a set of "initialization" operations. 
+ * The `reuse-last-initialized` strategy looks for the most recent run that matches particular criteria; if it cannot find one, it creates a new run and immediately executes a set of "initialization" operations.
  *
  * This strategy is useful if you have a time-based model and always want the run you're operating on to start at a particular step. For example:
  *
@@ -25,11 +25,11 @@ import { injectFiltersFromSession, injectScopeFromSession } from 'managers/run-s
  */
 export default class ReuseLastInitializedStrategy {
     /**
-     * 
-     * @param {object} [options] 
+     *
+     * @param {object} [options]
      * @property {object[]} [options.initOperation] Operations to execute in the model for initialization to be considered complete. Can be in any of the formats [Run Service's `serial()`](../run-api-service/#serial) supports.
      * @property {object} [options.flag] Flag to set in run after initialization operations are run. You typically would not override this unless you needed to set additional properties as well.
-     * @property {object} [options.scope] 
+     * @property {object} [options.scope]
      * @property {boolean} [options.scope.scopeByUser]  If true, only returns the last run for the user in session. Defaults to true.
      * @property {boolean} [options.scope.scopeByGroup] If true, only returns the last run for the group in session. Defaults to true.
      */
@@ -69,13 +69,14 @@ export default class ReuseLastInitializedStrategy {
         const sessionFilter = injectFiltersFromSession(this.options.flag, userSession, this.options.scope);
         const runopts = runService.getCurrentConfig();
         const filter = $.extend(true, { trashed: false }, sessionFilter, { model: runopts.model });
-        return runService.query(filter, { 
+        return runService.query(filter, {
             startrecord: 0,
             endrecord: 0,
-            sort: 'created', 
+            sort: 'created',
             direction: 'desc'
         }).then((runs)=> {
-            if (!runs.length) {
+            if (!runs.length || runs[0].trashed) {
+                // If no runs exist or the most recent run is trashed, create a new run
                 return this.reset(runService, userSession, options);
             }
             return runs[0];

--- a/src/managers/run-strategies/reuse-per-session.js
+++ b/src/managers/run-strategies/reuse-per-session.js
@@ -5,16 +5,16 @@ var __super = ConditionalStrategy.prototype;
 
 /**
  * The `reuse-per-session` strategy creates a new run when the current one is not in the browser cookie.
- * 
+ *
  * Using this strategy means that when end users navigate between pages in your project, or refresh their browsers, they will still be working with the same run. However, if end users log out and return to the project at a later date, a new run is created.
  *
  * This strategy is useful if your project is structured such that immediately after a run is created, the model is executed completely (for example, a Vensim model that is stepped to the end as soon as it is created). In contrast, if end users play with your project for an extended period of time, executing the model step by step, the `reuse-across-sessions` strategy is probably a better choice (it allows end users to pick up where they left off, rather than starting from scratch each browser session).
- * 
+ *
  * Specifically, the strategy is:
  *
  * * Check the `sessionKey` cookie.
- *     * This cookie is set by the [Run Manager](../run-manager/) and configurable through its options. 
- *     * If the cookie exists, use the run id stored there. 
+ *     * This cookie is set by the [Run Manager](../run-manager/) and configurable through its options.
+ *     * If the cookie exists, use the run id stored there.
  *     * If the cookie does not exist, create a new run for this end user.
  */
 var Strategy = classFrom(ConditionalStrategy, {
@@ -23,6 +23,10 @@ var Strategy = classFrom(ConditionalStrategy, {
     },
 
     createIf: function (run, headers) {
+        // If user refreshed and the faciliator deleted the run, create a new run
+        if (run.trashed) {
+            return true;
+        }
         // if we are here, it means that the run exists... so we don't need a new one
         return false;
     }

--- a/src/managers/run-strategies/tests/test-reuse-across-sessions.js
+++ b/src/managers/run-strategies/tests/test-reuse-across-sessions.js
@@ -60,7 +60,7 @@ describe('Reuse Across Sessions strategy', function () {
             return strategy.getRun(rs, auth).then(function () {
                 expect(queryStub).to.have.been.calledOnce;
                 var args = queryStub.getCall(0).args;
-                    
+
                 expect(args[0]).to.eql({
                     'user.id': auth.userId,
                     scope: {
@@ -73,6 +73,24 @@ describe('Reuse Across Sessions strategy', function () {
             var rs = new RunService(runOptions);
             sinon.stub(rs, 'query').callsFake(function () {
                 return $.Deferred().resolve([]);
+            });
+            var createStub = sinon.stub(rs, 'create').callsFake(function () {
+                return $.Deferred().resolve({
+                    id: 'def'
+                }).promise();
+            });
+            return strategy.getRun(rs, auth).then(function () {
+                expect(createStub).to.have.been.calledOnce;
+            });
+        });
+        it('should create new if latest run is trashed', function () {
+            var rs = new RunService(runOptions);
+            sinon.stub(rs, 'query').callsFake(function () {
+                return $.Deferred().resolve([{
+                    id: 'run1',
+                    date: '2016-10-21T00:07:55.735Z',
+                    trashed: true,
+                }]);
             });
             var createStub = sinon.stub(rs, 'create').callsFake(function () {
                 return $.Deferred().resolve({

--- a/src/managers/run-strategies/tests/test-reuse-last-initialized-strategy.js
+++ b/src/managers/run-strategies/tests/test-reuse-last-initialized-strategy.js
@@ -20,7 +20,7 @@ describe('Reuse last initialized', function () {
             var c = function () { new Strategy(); };
             expect(c).to.throw(Error);
         });
-    }); 
+    });
 
     describe('#getRun', function () {
         var rs, strategy, resetStub, queryStub;
@@ -100,6 +100,13 @@ describe('Reuse last initialized', function () {
             });
         });
         it('should call reset if not found', function () {
+            return strategy.getRun(rs, { userId: 'userId' }).then(function () {
+                expect(resetStub).to.have.been.calledOnce;
+            });
+        });
+        it('should call reset if run is trashed', function () {
+            var rs = new RunService(runOptions);
+            sinon.stub(rs, 'query').returns($.Deferred().resolve([{ id: 'x', trashed: true }]).promise());
             return strategy.getRun(rs, { userId: 'userId' }).then(function () {
                 expect(resetStub).to.have.been.calledOnce;
             });


### PR DESCRIPTION
Updated the following run strategies to create a new run if the latest run is trashed based on what made sense

- reuse-across-sessions
- reuse-by-tracking-key
- reuse-last-initialized
- reuse-per-session

Created tests for each